### PR TITLE
SMART: Fix Graph Scope Issue

### DIFF
--- a/samples/Patient and Population Services G10/src/SMARTCustomOperations.AzureAuth.UnitTests/Filters/AuthorizeInputFilterTests.cs
+++ b/samples/Patient and Population Services G10/src/SMARTCustomOperations.AzureAuth.UnitTests/Filters/AuthorizeInputFilterTests.cs
@@ -31,7 +31,7 @@ namespace SMARTCustomOperations.AzureAuth.UnitTests.Filters
             context.Request.Method = HttpMethod.Get;
             context.Request.RequestUri = new Uri(string.Concat(
                 "http://localhost/authorize",
-                "?response_type=code&client_id=xxxx-xxxxx-xxxxx-xxxxx&redirect_uri=http://localhost/&scope=patient/Patient.read fhir user openid",
+                "?response_type=code&client_id=xxxx-xxxxx-xxxxx-xxxxx&redirect_uri=http://localhost/&scope=patient/Patient.read fhirUser openid",
                 "&state=123&aud=https://workspace-fhir.fhir.azurehealthcareapis.com&code_challenge_method=S256&code_challenge=ECgEuvKylvpiOS9pF2pfu5NKoBErrx8fAWdneyiPT2E"));
 
             await filter.ExecuteAsync(context);
@@ -41,7 +41,6 @@ namespace SMARTCustomOperations.AzureAuth.UnitTests.Filters
             Assert.Equal($"/{config.TenantId}/oauth2/v2.0/authorize", context.Request.RequestUri.AbsolutePath);
 
             Assert.Equal(1, context.Headers.Count(x => x.Name == "Location"));
-            Assert.Equal(1, context.Headers.Count(x => x.Name == "Origin"));
         }
 
         [Fact]
@@ -73,7 +72,6 @@ namespace SMARTCustomOperations.AzureAuth.UnitTests.Filters
             Assert.Equal($"/{config.TenantId}/oauth2/v2.0/authorize", context.Request.RequestUri.AbsolutePath);
 
             Assert.Equal(1, context.Headers.Count(x => x.Name == "Location"));
-            Assert.Equal(1, context.Headers.Count(x => x.Name == "Origin"));
         }
 
         [Fact]

--- a/samples/Patient and Population Services G10/src/SMARTCustomOperations.AzureAuth.UnitTests/Filters/AuthorizeInputFilterTests.cs
+++ b/samples/Patient and Population Services G10/src/SMARTCustomOperations.AzureAuth.UnitTests/Filters/AuthorizeInputFilterTests.cs
@@ -31,7 +31,7 @@ namespace SMARTCustomOperations.AzureAuth.UnitTests.Filters
             context.Request.Method = HttpMethod.Get;
             context.Request.RequestUri = new Uri(string.Concat(
                 "http://localhost/authorize",
-                "?response_type=code&client_id=xxxx-xxxxx-xxxxx-xxxxx&redirect_uri=http://localhost/&scope=patient/Patient.read fhirUser openid",
+                "?response_type=code&client_id=xxxx-xxxxx-xxxxx-xxxxx&redirect_uri=http://localhost/&scope=patient/Patient.read fhir user openid",
                 "&state=123&aud=https://workspace-fhir.fhir.azurehealthcareapis.com&code_challenge_method=S256&code_challenge=ECgEuvKylvpiOS9pF2pfu5NKoBErrx8fAWdneyiPT2E"));
 
             await filter.ExecuteAsync(context);
@@ -41,6 +41,7 @@ namespace SMARTCustomOperations.AzureAuth.UnitTests.Filters
             Assert.Equal($"/{config.TenantId}/oauth2/v2.0/authorize", context.Request.RequestUri.AbsolutePath);
 
             Assert.Equal(1, context.Headers.Count(x => x.Name == "Location"));
+            Assert.Equal(1, context.Headers.Count(x => x.Name == "Origin"));
         }
 
         [Fact]
@@ -72,6 +73,7 @@ namespace SMARTCustomOperations.AzureAuth.UnitTests.Filters
             Assert.Equal($"/{config.TenantId}/oauth2/v2.0/authorize", context.Request.RequestUri.AbsolutePath);
 
             Assert.Equal(1, context.Headers.Count(x => x.Name == "Location"));
+            Assert.Equal(1, context.Headers.Count(x => x.Name == "Origin"));
         }
 
         [Fact]

--- a/samples/Patient and Population Services G10/src/SMARTCustomOperations.AzureAuth/Filters/TokenOutputFilter.cs
+++ b/samples/Patient and Population Services G10/src/SMARTCustomOperations.AzureAuth/Filters/TokenOutputFilter.cs
@@ -81,6 +81,17 @@ namespace SMARTCustomOperations.AzureAuth.Filters
 
             if (!tokenResponse["id_token"]!.IsNullOrEmpty())
             {
+                // Add the openid scope
+                if (tokenResponse["scope"]!.IsNullOrEmpty())
+                {
+                    tokenResponse["scope"] = "openid";
+                }
+                else
+                {
+                    tokenResponse["scope"] = tokenResponse["scope"]!.ToString() + " openid";
+                }   
+
+                // Attempt to parse fhirUser
                 try
                 {
                     var handler = new JwtSecurityTokenHandler();
@@ -99,6 +110,19 @@ namespace SMARTCustomOperations.AzureAuth.Filters
                 }
                 catch (Exception ex) {
                     _logger.LogWarning("fhirUser not found in id_token");
+                }
+            }
+
+            if (!tokenResponse["refresh_token"]!.IsNullOrEmpty())
+            {
+                // Add the openid scope
+                if (tokenResponse["scope"]!.IsNullOrEmpty())
+                {
+                    tokenResponse["scope"] = "offline_access";
+                }
+                else
+                {
+                    tokenResponse["scope"] = tokenResponse["scope"]!.ToString() + " offline_access";
                 }
             }
 

--- a/samples/Patient and Population Services G10/src/SMARTCustomOperations.AzureAuth/Models/AuthorizeContext.cs
+++ b/samples/Patient and Population Services G10/src/SMARTCustomOperations.AzureAuth/Models/AuthorizeContext.cs
@@ -55,7 +55,7 @@ namespace SMARTCustomOperations.AzureAuth.Models
 
         public AuthorizeContext Translate(string fhirServerAud)
         {
-            //_audience = fhirServerAud;
+            _audience = fhirServerAud;
             _scope = Scope.ParseScope(fhirServerAud);
             return this;
         }


### PR DESCRIPTION
`openid` and `offline_access` scopes were missing from the token response. adding back.

also adding back audience override logic to ensure tokens get formatted correctly